### PR TITLE
Add Support for Unattached Sources, Add Support for SEPA debit sources

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1346,5 +1346,134 @@ module StripeMock
         success_url: 'https://example.com/success'
       }.merge(params)
     end
+
+    def self.mock_card_source(params)
+      source_id = params[:id] || 'src_1FTsaLG0atmGm5bMw35CVkqx'
+      client_secret = 'src_client_secret_Gn0DSPa7gyGxsgO0zy7t2HGR'
+
+      card_data = {
+          exp_month: 1,
+          exp_year: 2026,
+          last4: '4242',
+          country: 'US',
+          brand: 'Visa',
+          cvc_check: 'pass',
+          funding: 'credit',
+          fingerprint: 'K4ShpsDP7vAx47WF',
+          three_d_secure: 'optional',
+          name: nil,
+          address_line1_check: nil,
+          address_zip_check: nil,
+          tokenization_method: nil,
+          dynamic_last4: nil
+        }
+
+        if params[:card]
+          if params[:card][:number]
+            card_data[:last4] = params[:card][:number][-4..-1]
+            params[:card].delete(:number)
+          end
+
+          params[:card].delete(:cvc) if params[:card][:cvc]
+        end
+
+        Util.rmerge({
+          id: source_id,
+          object: 'source',
+          amount: nil,
+          card: card_data,
+          client_secret: client_secret,
+          created: 1_571_390_788,
+          currency: nil,
+          customer: nil,
+          flow: 'none',
+          livemode: false,
+          metadata: {},
+          owner: { address: nil,
+                   email: nil,
+                   name: nil,
+                   phone: nil,
+                   verified_address: nil,
+                   verified_email: nil,
+                   verified_name: nil,
+                   verified_phone: nil },
+          statement_descriptor: nil,
+          status: 'chargeable',
+          type: 'card',
+          usage: 'reusable'
+        },
+        params)
+    end
+
+    def self.mock_sepa_debit_source(params)
+      source_id = params[:id] || 'src_1FTsaLG0atmGm5bMw35CVkqx'
+      client_secret = 'src_client_secret_Gn0DSPa7gyGxsgO0zy7t2HGR'
+
+      sepa_debit_data = {
+          last4: '3000',
+          bank_code: '37040044',
+          fingerprint: '3QSJ9dz1Xejd1k8z',
+          country: 'DE',
+          mandate_reference: 'kv9TakBIOKmlgTV8',
+          mandate_url: "https://hooks.stripe.com/adapter/sepa_debit/file/#{source_id}/#{client_secret}",
+          branch_code: nil
+        }
+
+        if params.dig(:sepa_debit, :iban)
+          sepa_debit_data[:last4] = params[:sepa_debit][:iban][-4..-1]
+          sepa_debit_data[:country] = params[:sepa_debit][:iban][0..1]
+          params[:sepa_debit].delete(:iban)
+        end
+
+        Util.rmerge({
+          id: source_id,
+          object: 'source',
+          amount: nil,
+          client_secret: client_secret,
+          created: 1_571_140_374,
+          currency: 'eur',
+          customer: nil,
+          flow: 'none',
+          livemode: false,
+          mandate: {
+            acceptance: { date: nil,
+                          ip: nil,
+                          offline: nil,
+                          online: nil,
+                          status: 'pending',
+                          type: nil,
+                          user_agent: nil },
+            amount: nil,
+            currency: nil,
+            interval: 'variable',
+            notification_method: 'none',
+            reference: 'kv9TakBIOKmlgTV8',
+            url: "https://hooks.stripe.com/adapter/sepa_debit/file/#{source_id}/#{client_secret}"
+          },
+          metadata: {},
+          owner: { address: nil,
+                   email: nil,
+                   name: 'John Doe',
+                   phone: nil,
+                   verified_address: nil,
+                   verified_email: nil,
+                   verified_name: nil,
+                   verified_phone: nil },
+          sepa_debit: sepa_debit_data,
+          statement_descriptor: nil,
+          status: 'chargeable',
+          type: 'sepa_debit',
+          usage: 'reusable'
+        },
+        params)
+    end
+
+    def self.mock_source(params)
+      if params[:type] == 'card'
+        mock_card_source(params)
+      elsif params[:type] == 'sepa_debit'
+        mock_sepa_debit_source(params)
+      end
+    end
   end
 end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -57,7 +57,7 @@ module StripeMock
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :payment_intents, :payment_methods,
                 :setup_intents, :plans, :prices, :recipients, :refunds, :transfers, :payouts, :subscriptions, :country_spec,
-                :subscriptions_items, :products, :tax_rates, :checkout_sessions
+                :subscriptions_items, :products, :tax_rates, :checkout_sessions, :unattached_sources
 
     attr_accessor :error_queue, :debug, :conversion_rate, :account_balance
 
@@ -86,6 +86,7 @@ module StripeMock
       @refunds = {}
       @transfers = {}
       @payouts = {}
+      @unattached_sources = {}
       @subscriptions = {}
       @subscriptions_items = {}
       @country_spec = {}

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -92,7 +92,7 @@ module StripeMock
             get_bank_by_token(params[:bank_account])
           else
             begin
-              get_card_by_token(params[:source])
+              source_from_unattached_sources(params[:source]) || get_card_by_token(params[:source])
             rescue Stripe::InvalidRequestError
               get_bank_by_token(params[:source])
             end
@@ -121,6 +121,10 @@ module StripeMock
         end
         card = get_card_by_token(attrs_or_token)
         validate_card(card)
+      end
+
+      def source_from_unattached_sources(source_id)
+        unattached_sources[source_id]
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -36,7 +36,7 @@ module StripeMock
 
       def get_card_or_bank_by_token(token)
         token_id = token['id'] || token
-        @card_tokens[token_id] || @bank_tokens[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', http_status: 404))
+        @card_tokens[token_id] || @bank_tokens[token_id] || @unattached_sources[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', http_status: 404))
       end
 
     end

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -9,6 +9,7 @@ module StripeMock
         klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
         klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
         klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
+        klass.add_handler 'post /v1/sources', :create_unattached_source
       end
 
       def create_source(route, method_url, params, headers)
@@ -50,6 +51,11 @@ module StripeMock
         bank_account
       end
 
+      def create_unattached_source(route, method_url, params, headers)
+        id = new_id('src')
+
+        unattached_sources[id] = Data.mock_source(params.merge(id: id))
+      end
     end
   end
 end


### PR DESCRIPTION
Original commit : https://github.com/dbdrive/stripe-ruby-mock/pull/1/commits/d70385136ef5973f4f4576b1c372534971f0c962