### PR TITLE
Subscriptions improvements

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -351,6 +351,7 @@ module StripeMock
           }]
         },
         cancel_at_period_end: false,
+        cancel_at: nil,
         canceled_at: nil,
         collection_method: 'charge_automatically',
         ended_at: nil,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -416,7 +416,8 @@ module StripeMock
         next_payment_attempt: 1349825350,
         charge: nil,
         discount: nil,
-        subscription: nil
+        subscription: nil,
+        payment_intent: nil,
       }.merge(params)
       if invoice[:discount]
         invoice[:total] = [0, invoice[:subtotal] - invoice[:discount][:coupon][:amount_off]].max if invoice[:discount][:coupon][:amount_off]

--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -1,7 +1,7 @@
 module StripeMock
   module Data
     class List
-      attr_reader :data, :limit, :offset, :starting_after, :ending_before, :active
+      attr_reader :data, :limit, :offset, :starting_after, :ending_before, :active, :include_total_count
 
       def initialize(data, options = {})
         @data = Array(data.clone)
@@ -16,6 +16,8 @@ module StripeMock
           @data.sort_by { |x| x.created }
           @data.reverse!
         end
+
+        @include_total_count = options[:"include[]"] && options[:"include[]"].include?("total_count")
       end
 
       def url
@@ -23,7 +25,9 @@ module StripeMock
       end
 
       def to_hash
-        { object: "list", data: data_page, url: url, has_more: has_more? }
+        { object: "list", data: data_page, url: url, has_more: has_more? }.tap { |h|
+          h[:total_count] = data.size if include_total_count
+        }
       end
       alias_method :to_h, :to_hash
 

--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -1,7 +1,7 @@
 module StripeMock
   module Data
     class List
-      attr_reader :data, :limit, :offset, :starting_after, :ending_before, :active, :include_total_count
+      attr_reader :data, :limit, :offset, :starting_after, :ending_before, :active, :include_total_count, :filter_by
 
       def initialize(data, options = {})
         @data = Array(data.clone)
@@ -18,6 +18,10 @@ module StripeMock
         end
 
         @include_total_count = options[:"include[]"] && options[:"include[]"].include?("total_count")
+
+        # Each object type can construct the list with an array of filterable attributes
+        # under "filterable_by" option.
+        @filter_by = options.slice(*(options[:filterable_by] || []).map(&:to_sym))
       end
 
       def url
@@ -71,6 +75,18 @@ module StripeMock
       def filtered_data
         filtered_data = data
         filtered_data = filtered_data.select { |d| d[:active] == active } unless active.nil?
+        filter_by.each do |key, value|
+          filtered_data.select! do |d|
+            next true if d[key] == value
+
+            # comparison is made with ids (string), stripe hash (mocks) representations
+            # or a Stripe object which also respond to []
+            data_id = d[key].is_a?(String) ? d[key] : d[key][:id]
+            value_id = value.is_a?(String) ? value : value[:id]
+
+            data_id == value_id
+          end
+        end
 
         filtered_data
       end

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -85,11 +85,19 @@ module StripeMock
       def get_ending_time(start_time, plan, intervals = 1)
         return start_time unless plan
 
-        case plan[:interval]
+        recurring = if plan[:object] == "plan"
+                      plan.slice(:interval, :interval_count)
+                    elsif plan[:object] == "price"
+                      plan[:recurring]
+                    else
+                      fail "Unsupported object #{plan[:object]}"
+                    end
+
+        case recurring[:interval]
         when "week"
-          start_time + (604800 * (plan[:interval_count] || 1) * intervals)
+          start_time + (604800 * (recurring[:interval_count] || 1) * intervals)
         when "month"
-          (Time.at(start_time).to_datetime >> ((plan[:interval_count] || 1) * intervals)).to_time.to_i
+          (Time.at(start_time).to_datetime >> ((recurring[:interval_count] || 1) * intervals)).to_time.to_i
         when "year"
           (Time.at(start_time).to_datetime >> (12 * intervals)).to_time.to_i # max period is 1 year
         else

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -229,6 +229,7 @@ module StripeMock
 
         plan_amount_was = subscription.dig(:plan, :amount)
 
+        params[:metadata] = subscription[:metadata].merge(params.fetch(:metadata) { {} } )
         subscription = resolve_subscription_changes(subscription, subscription_plans, customer, params)
 
         verify_card_present(customer, subscription_plans.first, subscription, params) if plan_amount_was == 0 && subscription.dig(:plan, :amount) && subscription.dig(:plan, :amount) > 0

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -136,6 +136,7 @@ module StripeMock
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i
+          subscription[:cancel_at] = subscription[:current_period_end]
         end
 
         if params[:expand] && params[:expand].include?('latest_invoice.payment_intent')
@@ -219,9 +220,11 @@ module StripeMock
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i
+          subscription[:cancel_at] = subscription[:current_period_end]
         elsif params.has_key?(:cancel_at_period_end)
           subscription[:cancel_at_period_end] = false
           subscription[:canceled_at] = nil
+          subscription[:cancel_at] = nil
         end
 
         params[:current_period_start] = subscription[:current_period_start]

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -173,9 +173,8 @@ module StripeMock
       def retrieve_subscriptions(route, method_url, params, headers)
         route =~ method_url
 
-        Data.mock_list_object(subscriptions.values, params)
-        #customer = assert_existence :customer, $1, customers[$1]
-        #customer[:subscriptions]
+        filterable = %w[customer plan price status]
+        Data.mock_list_object(subscriptions.values, params.merge(filterable_by: filterable))
       end
 
       def update_subscription(route, method_url, params, headers)

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -124,6 +124,25 @@ describe StripeMock::Data::List do
     end
   end
 
+  context "total_count option" do
+    it "doesn't include total_count by default" do
+      list = StripeMock::Data::List.new(double)
+      expect(list.to_h).not_to have_key(:total_count)
+    end
+
+    it "includes the total_count in the response" do
+      list = StripeMock::Data::List.new([double] * 10, :"include[]" => "total_count")
+
+      expect(list.to_h[:total_count]).to eq(10)
+    end
+
+    it "works well with limit" do
+      list = StripeMock::Data::List.new([double] * 10, limit: 1, :"include[]" => "total_count")
+
+      expect(list.to_h[:total_count]).to eq(10)
+    end
+  end
+
   context "pagination" do
     it "has a has_more field when it has more" do
       list = StripeMock::Data::List.new(

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe StripeMock::Data::List do
   let(:stripe_helper) { StripeMock.create_test_helper }
 
-  before :all do
+  before do
     StripeMock.start
   end
 
-  after :all do
+  after do
     StripeMock.stop
   end
 
@@ -169,6 +169,73 @@ describe StripeMock::Data::List do
       list = StripeMock::Data::List.new(data, starting_after: "test_ch_unknown")
 
       expect { list.to_h }.to raise_error
+    end
+  end
+
+  context "filters" do
+    it "can filter by parametered value" do
+      data = []
+      product_a = Stripe::Product.create(id: "prod_456", name: "My Beautiful Product", type: "service")
+      product_b = Stripe::Product.create(id: "prod_789", name: "My Beautiful Product", type: "service")
+      plan_attributes = { product: product_a.id, interval: "month", currency: "usd", amount: 500 }
+      plan_a = Stripe::Plan.create(plan_attributes)
+      plan_b = Stripe::Plan.create(**plan_attributes, active: false)
+      plan_c = Stripe::Plan.create(**plan_attributes, product: product_b.id)
+
+      list = StripeMock::Data::List.new([plan_a, plan_b, plan_c], filterable_by: %w[active product], active: true)
+      hash = list.to_h
+      expect(hash[:data].size).to eq(2)
+      expect(hash[:data].map(&:active)).to all(be(true))
+
+      list = StripeMock::Data::List.new([plan_a, plan_b, plan_c], filterable_by: %w[active product], active: true, product: "prod_456")
+      hash = list.to_h
+      expect(hash[:data].size).to eq(1)
+      expect(hash[:data][0]).to eq(plan_a)
+    end
+
+    it "can filter with an id against stripe hash representation" do
+      # Subscriptions have their plans expanded as a hash
+      product = stripe_helper.create_product
+      paid = stripe_helper.create_plan(id: 'paid', product: product.id, amount: 499)
+      free = stripe_helper.create_plan(id: 'free', product: product.id, amount: 0)
+      cus1 = Stripe::Customer.create(id: 'test_customer_sub1', source: stripe_helper.generate_card_token, plan: free.id)
+      cus2 = Stripe::Customer.create(id: 'test_customer_sub2', source: stripe_helper.generate_card_token, plan: free.id)
+      cus3 = Stripe::Customer.create(id: 'test_customer_sub3', source: stripe_helper.generate_card_token, plan: paid.id)
+
+      subscriptions = [cus1, cus2, cus3].map { |cus| cus.subscriptions.first.to_hash }
+      list = StripeMock::Data::List.new(subscriptions, filterable_by: %w[plan], plan: "free")
+      hash = list.to_h
+      expect(hash[:data].size).to eq(2)
+      expect(hash[:data].map { |s| s[:plan][:id] }).to all(be(free.id))
+    end
+
+    it "can filter with an id against stripe object" do
+      # Subscriptions have their plans expanded as a hash
+      product = stripe_helper.create_product
+      paid = stripe_helper.create_plan(id: 'paid', product: product.id, amount: 499)
+      free = stripe_helper.create_plan(id: 'free', product: product.id, amount: 0)
+      cus1 = Stripe::Customer.create(id: 'test_customer_sub1', source: stripe_helper.generate_card_token, plan: free.id)
+      cus2 = Stripe::Customer.create(id: 'test_customer_sub2', source: stripe_helper.generate_card_token, plan: free.id)
+      cus3 = Stripe::Customer.create(id: 'test_customer_sub3', source: stripe_helper.generate_card_token, plan: paid.id)
+
+      subscriptions = [cus1, cus2, cus3].map { |cus| cus.subscriptions.first }
+      list = StripeMock::Data::List.new(subscriptions, filterable_by: %w[plan], plan: "free")
+      hash = list.to_h
+      expect(hash[:data].size).to eq(2)
+      expect(hash[:data].map { |s| s[:plan][:id] }).to all(be(free.id))
+    end
+
+    it "can filter with a stripe object against an id" do
+      product = stripe_helper.create_product
+      free = stripe_helper.create_plan(id: 'free', product: product.id, amount: 0)
+      cus1 = Stripe::Customer.create(id: 'test_customer_sub1', source: stripe_helper.generate_card_token, plan: free.id)
+      cus2 = Stripe::Customer.create(id: 'test_customer_sub2', source: stripe_helper.generate_card_token, plan: free.id)
+
+      subscriptions = [cus1, cus2].map { |cus| cus.subscriptions.first.to_hash }
+      list = StripeMock::Data::List.new(subscriptions, filterable_by: %w[customer], customer: cus1)
+      hash = list.to_h
+      expect(hash[:data].size).to eq(1)
+      expect(hash[:data][0][:customer]).to eq(cus1.id)
     end
   end
 end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -777,13 +777,15 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.save).to be_truthy
       expect(sub.cancel_at_period_end).to be_truthy
       expect(sub.canceled_at).to be_truthy
+      expect(sub.cancel_at).to eq(sub.current_period_end)
 
       sub.cancel_at_period_end = false
       sub.save
 
       expect(sub.save).to be_truthy
       expect(sub.cancel_at_period_end).to be_falsey
-      expect(sub.canceled_at).to be_falsey
+      expect(sub.canceled_at).to be_nil
+      expect(sub.cancel_at).to be_nil
     end
 
     it "updates a subscription's pending invoice item interval" do
@@ -1069,6 +1071,7 @@ shared_examples 'Customer Subscriptions' do
       expect(result.status).to eq('canceled')
       expect(result.cancel_at_period_end).to eq false
       expect(result.canceled_at).to_not be_nil
+      expect(result.cancel_at).to be_nil
       expect(result.id).to eq(sub.id)
 
       customer = Stripe::Customer.retrieve(customer.id)
@@ -1088,6 +1091,7 @@ shared_examples 'Customer Subscriptions' do
 
     expect(result.status).to eq('active')
     expect(result.cancel_at_period_end).to eq(true)
+    expect(result.cancel_at).to eq(sub.current_period_end)
     expect(result.id).to eq(sub.id)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
@@ -1099,6 +1103,7 @@ shared_examples 'Customer Subscriptions' do
     expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(true)
     expect(customer.subscriptions.data.first.ended_at).to be_nil
     expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+    expect(customer.subscriptions.data.first.cancel_at).to eq(sub.current_period_end)
   end
 
   it "resumes a subscription cancelled by updating cancel_at_period_end" do
@@ -1113,6 +1118,7 @@ shared_examples 'Customer Subscriptions' do
 
     expect(result.status).to eq('active')
     expect(result.cancel_at_period_end).to eq(false)
+    expect(result.cancel_at).to be_nil
     expect(result.id).to eq(sub.id)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
@@ -1122,6 +1128,7 @@ shared_examples 'Customer Subscriptions' do
 
     expect(customer.subscriptions.data.first.status).to eq('active')
     expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(false)
+    expect(customer.subscriptions.data.first.cancel_at).to be_nil
     expect(customer.subscriptions.data.first.ended_at).to be_nil
     expect(customer.subscriptions.data.first.canceled_at).to be_nil
   end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1207,6 +1207,17 @@ shared_examples 'Customer Subscriptions' do
       expect(list.count).to eq(0)
       expect(list.data.length).to eq(0)
     end
+
+    it "retrieves a filter list of subscriptions" do
+      free_plan
+      paid = stripe_helper.create_plan(id: 'paid', product: product.id, amount: 499)
+      customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: free_plan.id)
+      subscription = Stripe::Subscription.create({ plan: 'paid', customer: customer.id })
+
+      subs = Stripe::Subscription.list(plan: free_plan.id)
+      expect(subs.count).to eq(1)
+      expect(subs.data[0][:plan]).to eq(free_plan)
+    end
   end
 
   describe "metadata" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1248,6 +1248,19 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.first.plan.id).to eq('Sample5')
       expect(customer.subscriptions.first.metadata['foo']).to eq('bar')
     end
-  end
 
+    it "conserves previous metadata when subscription is updated" do
+      # Stripe gem considers the metadata as additive
+      plan
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      subscription = Stripe::Subscription.create({
+        customer: customer.id,
+        items: [{ plan: 'silver' }],
+        metadata: { foo: "bar" },
+      })
+
+      subscription.save(cancel_at_period_end: true)
+      expect(subscription.metadata['foo']).to eq('bar')
+    end
+  end
 end


### PR DESCRIPTION
- expand latest_invoice.payment_intent
- cancel_at attribute set accordingly when cancel_at_period_end = true
- subscription with price
- updating a subscription conserve previously set metadata
- support subscriptions list filtering by customer, plan… (implemented as generic filtering logic)