### PR TITLE
Invoices improvements

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -373,6 +373,7 @@ module StripeMock
     end
 
     def self.mock_invoice(lines, params={})
+      now = Time.now.to_i
       in_id = params[:id] || "test_in_default"
       currency = params[:currency] || StripeMock.default_currency
       lines << Data.mock_line_item() if lines.empty?
@@ -381,9 +382,9 @@ module StripeMock
         status: 'open',
         invoice_pdf: 'pdf_url',
         hosted_invoice_url: 'hosted_invoice_url',
-        created: 1349738950,
-        period_end: 1349738950,
-        period_start: 1349738950,
+        created: now,
+        period_end: now,
+        period_start: now,
         due_date: nil,
         lines: {
           object: "list",
@@ -406,7 +407,7 @@ module StripeMock
         statement_descriptor: nil,
         tax: 10,
         tax_percent: nil,
-        webhooks_delivered_at: 1349825350,
+        webhooks_delivered_at: now,
         livemode: false,
         attempt_count: 0,
         amount_due: 100,
@@ -414,7 +415,7 @@ module StripeMock
         currency: currency,
         starting_balance: 0,
         ending_balance: 0,
-        next_payment_attempt: 1349825350,
+        next_payment_attempt: now,
         charge: nil,
         discount: nil,
         subscription: nil,
@@ -433,6 +434,7 @@ module StripeMock
     end
 
     def self.mock_line_item(params = {})
+      now = Time.now.to_i
       currency = params[:currency] || StripeMock.default_currency
       type = params.delete(:type) || (params[:subscription] ? "subscription" : "invoiceitem")
 
@@ -451,8 +453,8 @@ module StripeMock
         discountable: false,
         proration: false,
         period: {
-          start: 1349738920,
-          end: 1349738920
+          start: now,
+          end: now
         },
         tax_amounts: [
           {
@@ -468,11 +470,12 @@ module StripeMock
     end
 
     def self.mock_invoice_item(params = {})
+      now = Time.now.to_i
       currency = params[:currency] || StripeMock.default_currency
       {
         id: "test_ii",
         object: "invoiceitem",
-        created: 1349738920,
+        created: now,
         amount: 1099,
         livemode: false,
         proration: false,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -380,6 +380,12 @@ module StripeMock
       invoice = {
         id: 'in_test_invoice',
         status: 'open',
+        status_transitions: {
+          finalized_at: nil,
+          marked_uncollectible_at: nil,
+          paid_at: nil,
+          voided_at: nil,
+        },
         invoice_pdf: 'pdf_url',
         hosted_invoice_url: 'hosted_invoice_url',
         created: now,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -434,10 +434,17 @@ module StripeMock
 
     def self.mock_line_item(params = {})
       currency = params[:currency] || StripeMock.default_currency
+      type = params.delete(:type) || (params[:subscription] ? "subscription" : "invoiceitem")
+
+      invoice_item = if type == "invoiceitem"
+                       params.delete(:invoice_item) || Data.mock_invoice_item[:id]
+                     end
+
       {
         id: "ii_test",
         object: "line_item",
-        type: "invoiceitem",
+        type: type,
+        invoice_item: invoice_item,
         livemode: false,
         amount: 1000,
         currency: currency,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -454,7 +454,7 @@ module StripeMock
         ],
         quantity: nil,
         subscription: nil,
-        plan: nil,
+        price: nil,
         description: "Test invoice item",
         metadata: {}
       }.merge(params)
@@ -474,7 +474,8 @@ module StripeMock
         description: "invoice item desc",
         metadata: {},
         invoice: nil,
-        subscription: nil
+        subscription: nil,
+        price: nil,
       }.merge(params)
     end
 

--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -92,7 +92,12 @@ module StripeMock
       end
 
       def object_types
-        if first_object = data[0]
+        first_object = data[0]
+        return unless first_object
+
+        if first_object.is_a?(Hash) && first_object.key?(:object)
+          "#{first_object[:object]}s"
+        else
           "#{first_object.class.to_s.split('::')[-1].downcase}s"
         end
       end

--- a/lib/stripe_mock/request_handlers/invoice_items.rb
+++ b/lib/stripe_mock/request_handlers/invoice_items.rb
@@ -46,6 +46,8 @@ module StripeMock
 
         inject_price_object(item)
         compute_amount(item)
+
+        item
       end
 
       def delete_invoice_item(route, method_url, params, headers)
@@ -76,6 +78,8 @@ module StripeMock
         item = assert_existence :invoice_item, $1, invoice_items[$1]
 
         inject_price_object(item)
+
+        item
       end
 
       private
@@ -92,8 +96,6 @@ module StripeMock
 
         price = assert_existence :price, item[:price], prices[item[:price]]
         item[:price] = price
-
-        item
       end
 
       def inject_to_invoice(item)
@@ -114,9 +116,7 @@ module StripeMock
       def compute_amount(item)
         return item if item[:price].nil?
 
-        item[:amount] = item[:price][:amount]
-
-        item
+        item[:amount] = item[:price][:unit_amount]
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/invoice_items.rb
+++ b/lib/stripe_mock/request_handlers/invoice_items.rb
@@ -12,13 +12,19 @@ module StripeMock
 
       def new_invoice_item(route, method_url, params, headers)
         params[:id] ||= new_id('ii')
-        invoice_items[params[:id]] = Data.mock_invoice_item(params)
+
+        item = Data.mock_invoice_item(params)
+        inject_price_object(item)
+        compute_amount(item)
+        invoice_items[params[:id]] = item
       end
 
       def update_invoice_item(route, method_url, params, headers)
         route =~ method_url
-        list_item = assert_existence :list_item, $1, invoice_items[$1]
-        list_item.merge!(params)
+        item = assert_existence :list_item, $1, invoice_items[$1]
+        item.merge!(params)
+        inject_price_object(item)
+        compute_amount(item)
       end
 
       def delete_invoice_item(route, method_url, params, headers)
@@ -32,14 +38,40 @@ module StripeMock
       end
 
       def list_invoice_items(route, method_url, params, headers)
-        Data.mock_list_object(invoice_items.values, params)
+        items = invoice_items.values
+        items.each do |item|
+          inject_price_object(item)
+        end
+
+        Data.mock_list_object(items, params)
       end
 
       def get_invoice_item(route, method_url, params, headers)
         route =~ method_url
-        assert_existence :invoice_item, $1, invoice_items[$1]
+        item = assert_existence :invoice_item, $1, invoice_items[$1]
+
+        inject_price_object(item)
       end
 
+      private
+
+      def inject_price_object(item)
+        return item if item[:price].nil?
+        return item unless item[:price].is_a?(String)
+
+        price = assert_existence :price, item[:price], prices[item[:price]]
+        item[:price] = price
+
+        item
+      end
+
+      def compute_amount(item)
+        return item if item[:price].nil?
+
+        item[:amount] = item[:price][:amount]
+
+        item
+      end
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -28,6 +28,7 @@ module StripeMock
           raise Stripe::InvalidRequestError.new("Nothing to invoice for customer", http_status: 400) if pending_items.empty?
 
           line_items = pending_items.map { |ii|
+            ii[:invoice] = id
             Data.mock_line_item(id: new_id('il'), invoice_item: ii[:id])
           }
         end

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -14,8 +14,10 @@ module StripeMock
 
       def new_invoice(route, method_url, params, headers)
         id = new_id('in')
-        invoice_item = Data.mock_line_item()
-        invoices[id] = Data.mock_invoice([invoice_item], params.merge(:id => id, :status => "draft"))
+        invoice_item = Data.mock_invoice_item
+        invoice_items[invoice_item[:id]] = invoice_item
+        line_item = Data.mock_line_item(invoice_item: invoice_item[:id])
+        invoices[id] = Data.mock_invoice([line_item], params.merge(:id => id, :status => "draft"))
       end
 
       def update_invoice(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -29,13 +29,7 @@ module StripeMock
         params[:offset] ||= 0
         params[:limit] ||= 10
 
-        result = invoices.clone
-
-        if params[:customer]
-          result.delete_if { |k,v| v[:customer] != params[:customer] }
-        end
-
-        Data.mock_list_object(result.values, params)
+        Data.mock_list_object(invoices.values, params.merge(filterable_by: %w[customer status subscription]))
       end
 
       def get_invoice(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -78,6 +78,7 @@ module StripeMock
         merge_params = {
           status: "open",
           payment_intent: new_payment_intent("", "", payment_intent_params, {})[:id],
+          status_transitions: invoice[:status_transitions].merge(finalized_at: Time.now.to_i)
         }
 
         invoices[$1].merge!(merge_params)
@@ -186,6 +187,7 @@ module StripeMock
           status: "paid",
           amount_paid: invoice[:amount_due],
           amount_due:  0,
+          status_transitions: invoice[:status_transitions].merge(paid_at: Time.now.to_i),
         }
       end
 

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -30,7 +30,8 @@ module StripeMock
 
           line_items = pending_items.map { |ii|
             ii[:invoice] = id
-            Data.mock_line_item(id: new_id('il'), invoice_item: ii[:id], amount: ii[:amount])
+            amount = ii[:price] ? ii[:price][:unit_amount] : ii[:amount]
+            Data.mock_line_item(id: new_id('il'), invoice_item: ii[:id], amount: amount)
           }
         end
 

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -15,7 +15,7 @@ module StripeMock
       def new_invoice(route, method_url, params, headers)
         id = new_id('in')
         invoice_item = Data.mock_line_item()
-        invoices[id] = Data.mock_invoice([invoice_item], params.merge(:id => id))
+        invoices[id] = Data.mock_invoice([invoice_item], params.merge(:id => id, :status => "draft"))
       end
 
       def update_invoice(route, method_url, params, headers)
@@ -53,7 +53,7 @@ module StripeMock
         route =~ method_url
         assert_existence :invoice, $1, invoices[$1]
         charge = invoice_charge(invoices[$1])
-        invoices[$1].merge!(:paid => true, :attempted => true, :charge => charge[:id])
+        invoices[$1].merge!(:paid => true, :attempted => true, :charge => charge[:id], :status => "paid")
       end
 
       def upcoming_invoice(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -63,9 +63,10 @@ module StripeMock
 
       def pay_invoice(route, method_url, params, headers)
         route =~ method_url
-        assert_existence :invoice, $1, invoices[$1]
+        invoice = assert_existence :invoice, $1, invoices[$1]
         charge = invoice_charge(invoices[$1])
-        invoices[$1].merge!(:paid => true, :attempted => true, :charge => charge[:id], :status => "paid")
+
+        invoices[$1].merge!(invoice_pay_attributes(invoice, charge))
       end
 
       def upcoming_invoice(route, method_url, params, headers)
@@ -161,6 +162,17 @@ module StripeMock
           period_start: prorating ? invoice_date : preview_subscription[:current_period_start],
           period_end: prorating ? invoice_date : preview_subscription[:current_period_end],
           next_payment_attempt: preview_subscription[:current_period_end] + 3600 )
+      end
+
+      def invoice_pay_attributes(invoice, charge)
+        {
+          paid: true,
+          attempted: true,
+          charge: charge[:id],
+          status: "paid",
+          amount_paid: invoice[:amount_due],
+          amount_due:  0,
+        }
       end
 
       private

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -30,7 +30,7 @@ module StripeMock
 
           line_items = pending_items.map { |ii|
             ii[:invoice] = id
-            Data.mock_line_item(id: new_id('il'), invoice_item: ii[:id])
+            Data.mock_line_item(id: new_id('il'), invoice_item: ii[:id], amount: ii[:amount])
           }
         end
 

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -169,11 +169,18 @@ module StripeMock
         payment_intent[:status] = 'succeeded'
         btxn = new_balance_transaction('txn', { source: payment_intent[:id] })
 
-        payment_intent[:charges][:data] << Data.mock_charge(
+        charge = Data.mock_charge(
           balance_transaction: btxn,
           amount: payment_intent[:amount],
           currency: payment_intent[:currency]
         )
+
+        payment_intent[:charges][:data] << charge
+
+        if payment_intent[:invoice]
+          invoice = assert_existence :invoice, payment_intent[:invoice], invoices[payment_intent[:invoice]]
+          invoice.merge!(invoice_pay_attributes(invoice, charge))
+        end
 
         payment_intent
       end

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -53,6 +53,7 @@ module StripeMock
       end
 
       def create_unattached_source(route, method_url, params, headers)
+        route =~ method_url
         id = new_id('src')
 
         unattached_sources[id] = Data.mock_source(params.merge(id: id))
@@ -60,7 +61,7 @@ module StripeMock
 
       def retrieve_unattached_source(route, method_url, params, headers)
         route =~ method_url
-        assert_existence :unattached_source, $1, unattached_sources[$1]
+        assert_existence :unattached_sources, $1, unattached_sources[$1]
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/validators/param_validators.rb
+++ b/lib/stripe_mock/request_handlers/validators/param_validators.rb
@@ -135,10 +135,19 @@ module StripeMock
         end
       end
 
+      def validate_create_invoice_params(params)
+        customer_id = params[:customer].is_a?(Stripe::Customer) ? params[:customer][:id] : params[:customer]
+
+        raise Stripe::InvalidRequestError.new(missing_param_message(:customer), :customer) if customer_id.nil?
+
+        assert_existence :customer, customer_id, customers[customer_id]
+
+        params[:customer] = customer_id
+      end
+
       def require_param(param_name)
         raise Stripe::InvalidRequestError.new("Missing required param: #{param_name}.", param_name.to_s, http_status: 400)
       end
-
     end
   end
 end

--- a/lib/stripe_mock/webhook_fixtures/invoice.created.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.created.json
@@ -3,7 +3,6 @@
   "livemode": false,
   "id": "evt_00000000000000",
   "type": "invoice.created",
-  "status": "paid",
   "object": "event",
   "data": {
     "object": {
@@ -46,6 +45,7 @@
           }
         ]
       },
+      "status": "draft",
       "subtotal": 1000,
       "total": 1000,
       "customer": "cus_00000000000000",
@@ -56,6 +56,7 @@
       "livemode": false,
       "attempt_count": 1,
       "amount_due": 1000,
+      "amound_paid": 0,
       "currency": "usd",
       "starting_balance": 0,
       "ending_balance": 0,

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
@@ -8,7 +8,8 @@
     "object": {
       "id": "in_00000000000000",
       "object": "invoice",
-      "amount_due": 999,
+      "amount_due": 0,
+      "amount_paid": 999,
       "application_fee": null,
       "attempt_count": 1,
       "attempted": true,
@@ -101,6 +102,7 @@
       "receipt_number": null,
       "starting_balance": 0,
       "statement_descriptor": null,
+      "status": "paid",
       "subscription": "sub_00000000000000",
       "subtotal": 999,
       "tax": null,

--- a/lib/stripe_mock/webhook_fixtures/invoice.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.updated.json
@@ -3,7 +3,6 @@
   "livemode": false,
   "id": "evt_00000000000000",
   "type": "invoice.updated",
-  "status": "paid",
   "object": "event",
   "data": {
     "object": {
@@ -53,9 +52,11 @@
       "attempted": true,
       "closed": true,
       "paid": true,
+      "status": "paid",
       "livemode": false,
       "attempt_count": 1,
-      "amount_due": 1000,
+      "amount_due": 0,
+      "amound_paid": 1000,
       "currency": "usd",
       "starting_balance": 0,
       "ending_balance": 0,

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -34,6 +34,13 @@ describe StripeMock::Data::List do
     expect(list.url).to eq("/v1/customers")
   end
 
+  it "infers object type for url when list is initialized from mocks hash" do
+    charge = StripeMock::Data.mock_charge
+    list = StripeMock::Data::List.new([charge])
+
+    expect(list.url).to eq("/v1/charges")
+  end
+
   it "returns in descending order if created available" do
     charge_newer = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token, created: 5)
     charge_older = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token, created: 4)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -6,6 +6,7 @@ shared_examples 'Invoice API' do
     it "creates a stripe invoice" do
       invoice = Stripe::Invoice.create
       expect(invoice.id).to match(/^test_in/)
+      expect(invoice.status).to eq("draft")
     end
 
     it "stores a created stripe invoice in memory" do
@@ -83,6 +84,7 @@ shared_examples 'Invoice API' do
       @invoice = @invoice.pay
       expect(@invoice.attempted).to eq(true)
       expect(@invoice.paid).to eq(true)
+      expect(@invoice.status).to eq("paid")
     end
 
     it 'creates a new charge object' do

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -23,6 +23,23 @@ shared_examples 'Invoice API' do
       expect(data[invoice.id]).to_not be_nil
       expect(data[invoice.id][:id]).to eq(invoice.id)
     end
+
+    it "computes the total from items amounts" do
+      Stripe::InvoiceItem.create(customer: customer, amount: 500)
+      invoice = Stripe::Invoice.create(customer: customer)
+      expect(invoice.total).to eq(1500)
+      expect(invoice.amount_due).to eq(1500)
+    end
+
+    it "computes the total from items unit prices" do
+      product = stripe_helper.create_product
+      price = Stripe::Price.create(product: product.id, currency: "eur", unit_amount: 158)
+      Stripe::InvoiceItem.create(customer: customer, price: price.id)
+      invoice = Stripe::Invoice.create(customer: customer)
+
+      expect(invoice.total).to eq(1158)
+      expect(invoice.amount_due).to eq(1158)
+    end
   end
 
   context "retrieving an invoice" do

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -97,11 +97,15 @@ shared_examples 'Invoice API' do
       @invoice = Stripe::Invoice.create(customer: customer)
     end
 
-    it 'updates attempted and paid flags' do
+    it 'updates payable attributes' do
+      amount = @invoice.amount_due
       @invoice = @invoice.pay
+
       expect(@invoice.attempted).to eq(true)
       expect(@invoice.paid).to eq(true)
       expect(@invoice.status).to eq("paid")
+      expect(@invoice.amount_due).to eq(0)
+      expect(@invoice.amount_paid).to eq(amount)
     end
 
     it 'creates a new charge object' do

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -445,6 +445,10 @@ shared_examples 'Invoice API' do
         expect(line_items.data[0].object).to eq('line_item')
         expect(line_items.data[0].description).to eq('Test invoice item')
         expect(line_items.data[0].type).to eq('invoiceitem')
+
+        expect(line_items.data[0].invoice_item).to_not be_nil
+        invoice_item = Stripe::InvoiceItem.retrieve(line_items.data[0].invoice_item)
+        expect(invoice_item).to_not be_nil
       end
 
       it 'returns all line items for upcoming invoice' do
@@ -458,6 +462,7 @@ shared_examples 'Invoice API' do
         expect(line_items.data[0].object).to eq('line_item')
         expect(line_items.data[0].description).to eq('Test invoice item')
         expect(line_items.data[0].type).to eq('subscription')
+        expect(line_items.data[0].invoice_item).to be_nil
       end
     end
 

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -68,6 +68,12 @@ shared_examples 'Invoice API' do
       expect(Stripe::Invoice.list.has_more).to eq(true)
     end
 
+    it "filters by status" do
+      3.times { Stripe::Invoice.create(status: "open").pay }
+      expect(Stripe::Invoice.list(status: "draft").count).to eq(2)
+      expect(Stripe::Invoice.list(status: "paid").count).to eq(3)
+    end
+
     context "when passing limit" do
       it "gets that many invoices" do
         expect(Stripe::Invoice.list(limit: 1).count).to eq(1)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -101,6 +101,8 @@ shared_examples 'Invoice API' do
       @invoice.finalize_invoice
 
       expect(@invoice.status).to eq("open")
+      expect(@invoice.status_transitions.finalized_at).to eq(Time.now.to_i)
+      expect(@invoice.status_transitions.paid_at).to be_nil
     end
 
     it "creates and link payment intent" do
@@ -126,6 +128,7 @@ shared_examples 'Invoice API' do
       expect(@invoice.status).to eq("paid")
       expect(@invoice.amount_due).to eq(0)
       expect(@invoice.amount_paid).to eq(amount)
+      expect(@invoice.status_transitions.paid_at).to eq(Time.now.to_i)
     end
 
     it 'creates a new charge object' do

--- a/spec/shared_stripe_examples/invoice_item_examples.rb
+++ b/spec/shared_stripe_examples/invoice_item_examples.rb
@@ -22,6 +22,16 @@ shared_examples 'Invoice Item API' do
       expect(data[invoice_item.id]).to_not be_nil
       expect(data[invoice_item.id][:id]).to eq(invoice_item.id)
     end
+
+    it "creates a invoice item with a price" do
+      product = stripe_helper.create_product
+      price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+
+      invoice_item = Stripe::InvoiceItem.create(id: "ii_1", price: price.id)
+
+      expect(invoice_item.price).to eq(price)
+      expect(invoice_item.amount).to eq(158)
+    end
   end
 
   context "retrieving an invoice item" do
@@ -29,6 +39,18 @@ shared_examples 'Invoice Item API' do
       original = Stripe::InvoiceItem.create
       invoice_item = Stripe::InvoiceItem.retrieve(original.id)
       expect(invoice_item.id).to eq(original.id)
+    end
+
+    it "returns the invoice item with associated price instance" do
+      product = stripe_helper.create_product
+      price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+
+      Stripe::InvoiceItem.create(id: "ii_1", price: price.id)
+
+      invoice_item = Stripe::InvoiceItem.retrieve("ii_1")
+
+      expect(invoice_item.price).to eq(price)
+      expect(invoice_item.amount).to eq(158)
     end
   end
 
@@ -58,6 +80,22 @@ shared_examples 'Invoice Item API' do
     invoice_item = Stripe::InvoiceItem.retrieve("test_invoice_item_update")
     expect(invoice_item.amount).to eq(original.amount)
     expect(invoice_item.description).to eq('new desc')
+  end
+
+  it "updates a stripe invoice_item with a price" do
+    product = stripe_helper.create_product
+    price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+
+    original = Stripe::InvoiceItem.create(id: 'test_invoice_item_update')
+    original.price = price
+    original.save
+
+    expect(original.price).to eq(original.price)
+    expect(original.amount).to eq(158)
+
+    invoice_item = Stripe::InvoiceItem.retrieve("test_invoice_item_update")
+    expect(invoice_item.price).to eq(price)
+    expect(invoice_item.amount).to eq(158)
   end
 
   it "deletes a invoice_item" do

--- a/spec/shared_stripe_examples/invoice_item_examples.rb
+++ b/spec/shared_stripe_examples/invoice_item_examples.rb
@@ -25,7 +25,7 @@ shared_examples 'Invoice Item API' do
 
     it "creates a invoice item with a price" do
       product = stripe_helper.create_product
-      price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+      price = Stripe::Price.create(product: product.id, currency: "eur", unit_amount: 158)
 
       invoice_item = Stripe::InvoiceItem.create(id: "ii_1", price: price.id)
 
@@ -58,7 +58,7 @@ shared_examples 'Invoice Item API' do
 
     it "returns the invoice item with associated price instance" do
       product = stripe_helper.create_product
-      price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+      price = Stripe::Price.create(product: product.id, currency: "eur", unit_amount: 158)
 
       Stripe::InvoiceItem.create(id: "ii_1", price: price.id)
 
@@ -99,7 +99,7 @@ shared_examples 'Invoice Item API' do
 
   it "updates a stripe invoice_item with a price" do
     product = stripe_helper.create_product
-    price = Stripe::Price.create(product: product.id, currency: "eur", amount: 158)
+    price = Stripe::Price.create(product: product.id, currency: "eur", unit_amount: 158)
 
     original = Stripe::InvoiceItem.create(id: 'test_invoice_item_update')
     original.price = price


### PR DESCRIPTION
- invoice status "draft" at creation
- invoice status "paid" when paid
- add invoice filtering by status or subscription
- minor webhook fixtures improvements with amound_due/amount_paid
- InvoiceItem support `Price`
- Invoice are created with an `InvoiceLineItem` matching a "real" `InvoiceItem`
- Invoice creation context is more strict : customer must exist, and InvoiceItems or subscription as well
- supports `status_transitions` (for paid_at and finalized_at)
- supports `finalize` action
- paying an invoice updates the `amount_due/amount_paid` attributes
- confirming a `PaymentIntent` related to an invoice will update this invoice accordingly (status, amounts…)